### PR TITLE
fix: private server compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,7 +219,7 @@ addEventListener('message', event => {
 									text = `${text.substr(0, ii)},
 										host: ${JSON.stringify(backend.hostname)},
 										port: ${backend.port || '80'},
-										official: ${Boolean(version?.serverData?.shards?.[0])},
+										official: ${backend.hostname === 'screeps.com'},
 									} ${text.substr(ii + 1)}`;
 								}
 								break;
@@ -229,7 +229,7 @@ addEventListener('message', event => {
 				}
 				if (new URL(info.backend).hostname !== 'screeps.com') {
 					// Replace official CDN with local assets
-					text = text.replace(/https:\/\/d3os7yery2usni\.cloudfront\.net\//g, `${info.backend}/assets/`);
+					text = text.replace(/https:\/\/d3os7yery2usni\.cloudfront\.net\/map\/\w+\//g, `${info.backend}/assets/map/`);
 				}
 			}
 			return beautify ? jsBeautify(text) : text;
@@ -277,8 +277,8 @@ koa.use(async(context, next) => {
 			context.req.url = info.endpoint;
 			if (info.endpoint.startsWith("/api/auth")) {
 				const returnUrl = encodeURIComponent(info.backend);
-        context.req.url = `${info.endpoint}${info.endpoint.includes('?') ? '&' : '?'}returnUrl=${returnUrl}`;
-      }
+				context.req.url = `${info.endpoint}${info.endpoint.includes('?') ? '&' : '?'}returnUrl=${returnUrl}`;
+			}
 			proxy.web(context.req, context.res, {
 				target: argv.internal_backend ?? info.backend,
 			});


### PR DESCRIPTION
### Changes

* sets the `official` flag to be based on the backend hostname matching screeps.com or the server's version api containing the `official-like` feature flag (xxscreeps)

This fixes the world and room views when connected to private servers that have a shard name set via screepsmod-admin-utils.

| world map before | after |
|----|----|
|  ![world_before](https://github.com/laverdet/screeps-steamless-client/assets/10291543/bd602acb-f64f-498a-9ac2-f406615fcaf3) | ![world_after](https://github.com/laverdet/screeps-steamless-client/assets/10291543/ee56c233-3df0-4468-9d91-1dba4e337daa) |

| room view before | after |
|----|----|
| ![room_before](https://github.com/laverdet/screeps-steamless-client/assets/10291543/2c7ad136-626b-4683-8e9d-fcf6cae92a59) | ![room_after](https://github.com/laverdet/screeps-steamless-client/assets/10291543/7eb8dbc2-5e43-4de7-a5c4-6a51390271b3) |
